### PR TITLE
Remove origin from eventmanager

### DIFF
--- a/charts/matrixbot/Chart.yaml
+++ b/charts/matrixbot/Chart.yaml
@@ -1,4 +1,4 @@
 description: Web3 Foundation bot for matrix.org
 name: matrixbot
-version: v1.1.0
+version: v1.1.1
 apiVersion: v2

--- a/skills/skill-alertmanager/__init__.py
+++ b/skills/skill-alertmanager/__init__.py
@@ -23,12 +23,23 @@ class AlertManager(Skill):
                 msg = alert["annotations"]["message"]
             elif "description" in alert["annotations"]:
                 msg = alert["annotations"]["description"]
-            await self.opsdroid.send(Message(str(
-                "{status} {name} ({severity}): {message} in: {origin}".format(
-                    status=alert["status"].upper(),
-                    name=alert["labels"]["alertname"],
-                    severity=alert["labels"]["severity"].upper(),
-                    origin=alert["labels"]["origin"].upper(),
-                    message=msg)
-                ))
-            )
+
+            if "origin" in alert["labels"]:
+                await self.opsdroid.send(Message(str(
+                    "{status} {name} ({severity}): {message} in: {origin}".
+                    format(
+                        status=alert["status"].upper(),
+                        name=alert["labels"]["alertname"],
+                        severity=alert["labels"]["severity"].upper(),
+                        origin=alert["labels"]["origin"].upper(),
+                        message=msg)
+                )))
+            else:
+                await self.opsdroid.send(Message(str(
+                    "{status} {name} ({severity}): {message}".
+                    format(
+                        status=alert["status"].upper(),
+                        name=alert["labels"]["alertname"],
+                        severity=alert["labels"]["severity"].upper(),
+                        message=msg)
+                )))

--- a/skills/skill-eventmanager/__init__.py
+++ b/skills/skill-eventmanager/__init__.py
@@ -27,10 +27,9 @@ class EventManager(Skill):
             elif "description" in alert["annotations"]:
                 msg = alert["annotations"]["description"]
             await self.opsdroid.send(Message(str(
-                "{severity} {name}: {message} in: {origin}".format(
+                "{severity} {name}: {message}".format(
                     name=alert["labels"]["alertname"],
                     severity=alert["labels"]["severity"].upper(),
-                    origin=alert["labels"]["origin"].upper(),
                     message=msg)
                 ))
             )


### PR DESCRIPTION
Origin only makes sense for alerts. This PR also prevents errors if it is not present.